### PR TITLE
Add order/secret request validation

### DIFF
--- a/pkg/defaultservice/order.go
+++ b/pkg/defaultservice/order.go
@@ -92,6 +92,11 @@ func (s *Service) ValidateOrderRequest(req *api.OrderRequest) error {
 	return nil
 }
 
+//ValidateOrderSecretRequest - Validate fields in the Order Secret
+func (s *Service) ValidateOrderSecretRequest(req *api.OrderRequest) error {
+	return nil
+}
+
 // PrepareOrderPart1 is called before the order is send
 func (s *Service) PrepareOrderPart1(order *documents.OrderDoc, reqExtension map[string]string) (fulfillExtension map[string]string, err error) {
 	return nil, nil
@@ -213,6 +218,12 @@ func (s *Service) OrderSecret(req *api.OrderSecretRequest) (*api.OrderSecretResp
 	if err != nil {
 		return nil, errors.Wrap(err, "Fail to retrieve Order from IPFS")
 	}
+
+	if err := s.Plugin.ValidateOrderSecretRequest(req, *order); err != nil {
+		return nil, err
+	}
+
+	//Create a piece of data that is destined for the beneficiary, passed via the Master Fiduciary
 
 	beneficiaryEncryptedData, extension, err := s.Plugin.ProduceBeneficiaryEncryptedData(blsSK, order, req)
 	if err != nil {

--- a/pkg/defaultservice/plugable.go
+++ b/pkg/defaultservice/plugable.go
@@ -30,6 +30,7 @@ type Plugable interface {
 
 	// order
 	ValidateOrderRequest(req *api.OrderRequest) error
+	ValidateOrderSecretRequest(req *api.OrderSecretRequest, order documents.OrderDoc) error
 	PrepareOrderPart1(order *documents.OrderDoc, reqExtension map[string]string) (fulfillExtension map[string]string, err error)
 	PrepareOrderResponse(orderPart2 *documents.OrderDoc, reqExtension, fulfillExtension map[string]string) (commitment string, extension map[string]string, err error)
 	ProduceBeneficiaryEncryptedData(blsSK []byte, order *documents.OrderDoc, req *api.OrderSecretRequest) (encrypted []byte, extension map[string]string, err error)


### PR DESCRIPTION
Add validation to trap /order & /order/secret beneficiary inconsistencies.
1) Create error when beneficiaries are not specified at all
2) Create error when Beneficiaries specified in both, and different
3) Ignore Beneficiary in /order/secret when the beneficiary has already been specified in /order.