### PR TITLE
Beneficiary fix

### DIFF
--- a/cmd/servicetester/e2e_test.sh
+++ b/cmd/servicetester/e2e_test.sh
@@ -3,6 +3,7 @@
 
 apiVersion="v1"
 
+
 status () {
   #Determine if an extension is running
   statusOutput=$(curl -s -X GET "http://localhost:5556/$apiVersion/status" -H "accept: */*" -H "Content-Type: application/json")
@@ -20,10 +21,10 @@ status () {
 ###############################################################################################################################
 
 execute_bitcoin () {
-  #Run 2 Tests against the Bitcoin Extension
-  echo "Bitcoin Plugin Tests [2 Tests]"
+  # #Run 4 Tests against the Bitcoin Extension
+  echo "Bitcoin Plugin Tests [4 Tests]"
   output1=$(curl -s -X POST "http://localhost:5556/$apiVersion/order" -H "accept: */*" -H "Content-Type: application/json" -d "{\"beneficiaryIDDocumentCID\":\"\",\"extension\":{\"coin\":\"0\"}}")
-  echo $output1
+  #echo $output1
   op1=$(echo $output1 | jq .orderReference)
   commitment1=$(echo $output1 | jq .commitment)
   address1=$(echo $output1 | jq .extension.address)
@@ -71,6 +72,67 @@ execute_bitcoin () {
       echo "Fail"
       exit 1
   fi
+
+
+   #make another BeneficiaryID
+   output5=$(curl -s -X POST "http://localhost:5556/$apiVersion/identity" -H "accept: */*" -H       "Content-Type: application/json" -d "{\"Name\":\"AA\"}")
+   benid=$(echo $output5 | jq -r .idDocumentCID)
+
+
+
+   #Tests against the Bitcoin Extension - different befificary
+   output6=$(curl -s -X POST "http://localhost:5556/$apiVersion/order" -H "accept: */*" -H "Content-Type: application/json" -d "{\"beneficiaryIDDocumentCID\":\"\",\"extension\":{\"coin\":\"0\"}}")
+   #echo $output6
+   op6=$(echo $output6 | jq .orderReference)
+   commitment6=$(echo $output6 | jq .commitment)
+   address6=$(echo $output6 | jq .extension.address)
+
+   output7=$(curl -s -X POST "http://localhost:5556/$apiVersion/order/secret" -H "accept: */*" -H "Content-Type: application/json" -d "{\"orderReference\":$op6,\"beneficiaryIDDocumentCID\":\"$benid\"}")
+   address7=$(echo $output7 | jq .extension.address)
+   commitment7=$(echo $output7 | jq .commitment)
+
+   echo "Committment5 $commitment6 $address6"
+   echo "Committment6 $commitment7 $address7"
+
+   if [ -z $commitment7 ]; then
+       echo "Failed Commitment is empty"
+       exit 1
+   fi
+
+   if [ $commitment6 == $commitment7 ]; then
+     echo "Pass - Id, Order & OrderSecret(Beneficiary)"
+   else
+     echo "Fail"
+     exit 1
+   fi
+
+  output8=$(curl -s -X POST "http://localhost:5556/$apiVersion/order" -H "accept: */*" -H "Content-Type: application/json" -d "{\"beneficiaryIDDocumentCID\":\"$benid\",\"extension\":{\"coin\":\"0\"}}")
+  op8=$(echo $output8 | jq .orderReference)
+  commitment8=$(echo $output8 | jq .commitment)
+  address8=$(echo $output8 | jq .extension.address)
+
+
+  output9=$(curl -s -X POST "http://localhost:5556/$apiVersion/order/secret" -H "accept: */*" -H "Content-Type: application/json" -d "{\"orderReference\":$op8}")
+  commitment9=$(echo $output9 | jq .commitment)
+  address9=$(echo $output9 | jq .extension.address)
+  orderReference=$(echo $output9 | jq .orderReference)
+  orderIndex=1
+
+  echo "Committment7 $commitment8 $address8"
+  echo "Committment8 $commitment9 $address9"
+
+  if [ -z $commitment9 ]; then
+      echo "Failed Commitment is empty"
+      exit 1
+  fi
+
+  if [ $commitment8 == $commitment9 ]; then
+    echo "Pass - Id, Order(Beneficiary) & OrderSecret"
+  else
+      echo "Fail"
+      exit 1
+  fi
+
 }
 
 
@@ -108,7 +170,7 @@ execute_safeguardsecret () {
 execute_milagro () {
   echo "Milagro Tests [1 Test]"
   output1=$(curl -s -X POST "http://localhost:5556/$apiVersion/order" -H "accept: */*" -H "Content-Type: application/json" -d "{\"beneficiaryIDDocumentCID\":$identity}")
-  echo $output1  
+  echo $output1
   op1=$(echo $output1 | jq .orderReference)
 
 

--- a/pkg/bitcoinplugin/helpers.go
+++ b/pkg/bitcoinplugin/helpers.go
@@ -53,10 +53,10 @@ func deriveFinalPrivateKey(s *Service, order documents.OrderDoc, beneficiariesSi
 
 	//we are using the beneficiary specified in the order part 1
 	privateKeyPart2of2 := order.OrderDocument.OrderPart4.Secret
-	if order.OrderDocument.BeneficiaryCID != nodeID {
-		//need to forward this data to the beneficiary to complete redemption
-		return "", errors.New("Currently beneficiary must be the same as the Principal")
-	}
+	// if order.OrderDocument.BeneficiaryCID != nodeID {
+	// 	//need to forward this data to the beneficiary to complete redemption
+	// 	return "", errors.New("Currently beneficiary must be the same as the Principal")
+	// }
 	//restore the Seed
 	_, _, ecAddPrivateKey, err := cryptowallet.Bip44Address(beneficiariesSeed, cryptowallet.CoinTypeBitcoinMain, 0, 0, 0)
 	if err != nil {


### PR DESCRIPTION
Fix: When Beneficiary is specified, ensure the Bitcoin Wallet is generated with the EC keys from beneficiary not principal
Add: 2 End to End tests, to test when Principal != Beneficiary